### PR TITLE
Added basic achievements menu with persistent achievements

### DIFF
--- a/game/achievements.rpy
+++ b/game/achievements.rpy
@@ -1,0 +1,90 @@
+init python:
+    import json
+    import os
+
+    # Mapping of achievement title to (index, description)
+    # The index is so achievements stay in order on the achivements page.
+    ACHIEVEMENTS = {
+        "First Death": (0, "Die for the first time."),
+        "Fake Protagonist": (1, "Discover the truth behind the agent's fate."),
+        "Corruption": (2, "Watch Sonny or Fulgur succumb to corruption."),
+        "Kleptomaniac": (3, "Placeholder text for Alban's achievement."),
+        "Psychic": (4, "Placeholder text for Uki's achievement."),
+        "Do You Read Me?": (5, "Placeholder text for Fulgur's achievement."),
+        "Lightning Fast": (6, "Placeholder text for achievement."),
+        "True Ending": (7, "Reach the true ending of Noctyx's story."),
+    }
+
+    class Achievement:
+        """In-game achievements."""
+        def __init__(self, title, completed=False) -> None:
+            self.title = title
+            self.completed = completed
+
+    class AchievementTracker:
+        """Tracker for in-game achievements."""
+
+        SAVE_FILENAME = "saved_achievements.txt"
+
+        def __init__(self) -> None:
+            self.num_completed = 0
+            self.num_achievements = len(ACHIEVEMENTS)
+            self.load_achievements()
+
+        def initialize_achievements(self):
+            """Initialize achievements from scratch."""
+            self.achievements = {}
+            for title, _ in ACHIEVEMENTS.items():
+                self.achievements[title] = Achievement(title)
+
+        def load_achievements(self):
+            """Load achievements from save directory."""
+            save_filename = os.path.join(config.savedir, self.SAVE_FILENAME)
+            if not os.path.exists(save_filename):
+                self.initialize_achievements()
+            else:
+                num_completed = 0
+                self.achievements = {}
+                with open(save_filename, "r") as f:
+                    achievement_str = f.read()
+                for achievement in json.loads(achievement_str):
+                    if achievement["completed"]:
+                        num_completed += 1
+                    title = achievement["title"]
+                    self.achievements[title] = Achievement(**achievement)
+                self.num_completed = num_completed
+
+        def save_achievements(self):
+            """Save achievements to the save directory."""
+            save_filename = os.path.join(config.savedir, self.SAVE_FILENAME)
+            achievement_lst = []
+            for achievement in self.achievements.values():
+                achievement_lst.append(achievement.__dict__)
+            with open(save_filename, "w") as f:
+                f.write(json.dumps(achievement_lst))
+
+        def clear_saved_achievements(self):
+            """
+            Clear saved achievements, including the savefile.
+            For testing purposes only.
+            """
+            save_filename = os.path.join(config.savedir, self.SAVE_FILENAME)
+            if os.path.exists(save_filename):
+                os.remove(save_filename)
+            self.num_completed = 0
+            self.initialize_achievements()
+
+        def complete_achievement(self, name) -> None:
+            """Mark achievement as completed."""
+            self.achievements[name].completed = True
+            self.num_completed += 1
+            self.save_achievements()
+
+        def get_sorted_achievements(self):
+            """Get Achievements sorted by index."""
+            return sorted(
+                self.achievements.values(),
+                key=lambda a: ACHIEVEMENTS[a.title][0]
+            )
+
+    achievement_tracker = AchievementTracker()

--- a/game/options.rpy
+++ b/game/options.rpy
@@ -142,7 +142,7 @@ default preferences.afm_time = 15
 ## This generally should not be changed, and if it is, should always be a
 ## literal string, not an expression.
 
-define config.save_directory = "noctyx_before_corruption-1701409082"
+define config.save_directory = "noctyx_before_corruption"
 
 
 ## Icon ########################################################################

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -307,6 +307,8 @@ screen navigation():
 
         textbutton _("Load") action ShowMenu("load")
 
+        textbutton _("Achievements") action ShowMenu("achievements")
+
         textbutton _("Preferences") action ShowMenu("preferences")
 
         if _in_replay:
@@ -1605,3 +1607,76 @@ style slider_vbox:
 style slider_slider:
     variant "small"
     xsize 900
+
+
+## Achievements screen ##########################################################
+##
+## The achievements screen allows the player to see what achievements they've completed.
+##
+
+screen achievements():
+
+    tag menu
+
+    use game_menu(_("Achievements"), scroll="viewport"):
+
+        style_prefix "achievements"
+
+        vbox:
+            style "achievements_vbox"
+            label "[achievement_tracker.num_completed]/[achievement_tracker.num_achievements] Completed"
+            xalign 0.5
+
+            for achievement in achievement_tracker.get_sorted_achievements():
+                if achievement.completed:
+                    $ description = ACHIEVEMENTS[achievement.title][1]
+                    $ styling = "completed"
+                else:
+                    $ description = "Locked"
+                    $ styling = "locked"
+
+                hbox:
+                    style_prefix "achievement_" + styling
+                    hbox:
+                        style "achievement_title"
+                        text "[achievement.title]"
+
+                    hbox:
+                        style "achievement_description"
+                        text "[description]"
+
+
+style achievements_label is gui_label
+style achievements_label_text is gui_label_text
+
+style achievements_label:
+    xfill True
+    bottom_margin 30
+
+style achievements_label_text:
+    xalign 0.5
+
+style achievements_vbox is default
+style achievement_title is default
+style achievement_description is default
+style achievement_completed_text is gui_text
+style achievement_locked_text is gui_text
+
+style achievements_vbox:
+    spacing 30
+
+style achievement_title:
+    xsize 350
+    bottom_margin 30
+
+style achievement_description:
+    box_wrap True
+    xfill True
+    left_margin 30
+    bottom_margin 30
+
+style achievement_completed_text:
+    color "#ffffff"
+
+style achievement_locked_text:
+    color "#888888"

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -26,7 +26,11 @@ label start:
 
     e "You've created a new Ren'Py game."
 
+    $ achievement_tracker.complete_achievement("Fake Protagonist")
+
     e "Once you add a story, pictures, and music, you can release it to the world!"
+
+    $ achievement_tracker.complete_achievement("True Ending")
 
     # This ends the game.
 


### PR DESCRIPTION
Initial prototype for an achievements menu until we have a more concrete design.

Achievement menu can be accessed from the start menu (before game is loaded) or in the pause menu. Currently just includes achievement name and description as well as number of completed achievements. Example usage can be seen in the script.

Achievements progress will be saved in a file in the save directory; this means that they should persist across multiple saves and between the game opening and closing, so different achievements can be accomplished on different savefiles.

Screenshot:
![achievements_menu](https://github.com/athamante/noctyx_before_corruption/assets/152583383/55643e54-2ea0-4164-88da-8c8b4afac72e)

