### PR TITLE
Added dress-up-game prototype with placeholder image

### DIFF
--- a/game/dress_up.rpy
+++ b/game/dress_up.rpy
@@ -1,0 +1,104 @@
+# Placeholder for testing purposes
+image smaller_uki:
+    "sprites/uki/default.png"
+    zoom 0.8
+
+screen dress_up_minigame():
+    hbox:
+        frame:
+            style "dress_up_display"
+            # This should be the actual command, but since we don't have the pieces
+            # to make the composite sprite we're using a placeholder for now.
+            # add "uki_sprite" at truecenter
+            add "smaller_uki" at truecenter
+
+        frame:
+            style_prefix "dress_up_choices"
+
+            vbox:
+                label "Choose your outfit for the day!"
+
+                # Currently assumes four variations of every option, can be updated later.
+                hbox:
+                    textbutton "Prev" action SetVariable("uki_hair_index", (uki_hair_index - 1) % 4)
+                    text "Hair"
+                    textbutton "Next" action SetVariable("uki_hair_index", (uki_hair_index + 1) % 4)
+
+                hbox:
+                    textbutton "Prev" action SetVariable("uki_eyewear_index", (uki_eyewear_index - 1) % 4)
+                    text "Eyewear"
+                    textbutton "Next" action SetVariable("uki_eyewear_index", (uki_eyewear_index + 1) % 4)
+
+                hbox:
+                    textbutton "Prev" action SetVariable("uki_outerwear_index", (uki_outerwear_index - 1) % 4)
+                    text "Outerwear"
+                    textbutton "Next" action SetVariable("uki_outerwear_index", (uki_outerwear_index + 1) % 4)
+
+                hbox:
+                    textbutton "Prev" action SetVariable("uki_top_index", (uki_top_index - 1) % 4)
+                    text "Top"
+                    textbutton "Next" action SetVariable("uki_top_index", (uki_top_index + 1) % 4)
+
+
+                hbox:
+                    textbutton "Prev" action SetVariable("uki_bottom_index", (uki_bottom_index - 1) % 4)
+                    text "Bottom"
+                    textbutton "Next" action SetVariable("uki_bottom_index", (uki_bottom_index + 1) % 4)
+
+                hbox:
+                    textbutton "Prev" action SetVariable("uki_shoes_index", (uki_shoes_index - 1) % 4)
+                    text "Shoes"
+                    textbutton "Next" action SetVariable("uki_shoes_index", (uki_shoes_index + 1) % 4)
+
+                hbox:
+                    textbutton "Done" action Return()
+
+style dress_up_display is gui_frame
+style dress_up_choices_frame is gui_frame
+style dress_up_choices_vbox is default
+style dress_up_choices_hbox is default
+style dress_up_choices_label is gui_label
+style dress_up_choices_text is gui_text
+style dress_up_choices_button is gui_button
+style dress_up_choices_button_text is gui_button_text
+
+style dress_up_display:
+    xsize 1200
+    xmargin 20
+    ymargin 20
+    yfill True
+
+style dress_up_choices_frame:
+    xfill True
+    yfill True
+    ymargin 20
+    right_margin 20
+
+style dress_up_choices_vbox:
+    yfill True
+    xfill True
+    xalign 0.5
+    yalign 0.5
+
+style dress_up_choices_label:
+    ymargin 30
+    xalign 0.5
+    yalign 0.5
+
+style dress_up_choices_hbox:
+    xalign 0.5
+    xsize 300
+    bottom_margin 20
+
+style dress_up_choices_text:
+    xsize 150
+    xmargin 10
+    xalign 0.5
+    yalign 0.5
+
+style dress_up_choices_button:
+    xalign 0.5
+    xsize 150
+
+style dress_up_choices_button_text:
+    xalign 0.5

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -33,6 +33,8 @@ label start:
     scene clothing_store
     call screen dress_up_minigame
 
+    show eileen happy
+
     e "Did you have fun picking an outfit?"
 
     # This ends the game.

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -28,6 +28,13 @@ label start:
 
     e "Once you add a story, pictures, and music, you can release it to the world!"
 
+    e "Let's test out the dress-up minigame."
+
+    scene clothing_store
+    call screen dress_up_minigame
+
+    e "Did you have fun picking an outfit?"
+
     # This ends the game.
 
     return

--- a/game/sprites.rpy
+++ b/game/sprites.rpy
@@ -25,12 +25,40 @@ image sonny_upset = "sprites/sonny/upset.png"
 image sonny_corrupted = "sprites/sonny/corrupted.png"
 
 ## Uki Sprites
-image uki_default = "sprites/uki/default.png"
-image uki_smile = "sprites/uki/smile.png"
-image uki_concerned = "sprites/uki/concerned.png"
-image uki_serious = "sprites/uki/serious.png"
-image uki_upset = "sprites/uki/upset.png"
-image uki_pout = "sprites/uki/pout.png"
+default uki_hair_index = 0
+default uki_eyewear_index = 0
+default uki_top_index = 0
+default uki_outerwear_index = 0
+default uki_bottom_index = 0
+default uki_shoes_index = 0
+default uki_expression = "default"
+
+image uki_hair = "sprites/uki/hair[uki_hair_index].png"
+image uki_eyewear = "sprites/uki/eyewear[uki_eyewear_index].png"
+image uki_top = "sprites/uki/top[uki_top_index].png"
+image uki_outerwear = "sprites/uki/outerwear[uki_outerwear_index].png"
+image uki_bottom = "sprites/uki/bottom[uki_bottom_index].png"
+image uki_shoes = "sprites/uki/shoes[uki_shoes_index].png"
+image uki_face = "sprites/uki/[uki_expression].png"
+
+# Placeholder sprite size and component position
+define sprite_size = (276, 1080)
+define placeholder_pos = (0, 0)
+
+image uki_sprite = Composite(
+    sprite_size,
+    placeholder_pos, "uki_shoes",
+    placeholder_pos, "uki_bottom",
+    placeholder_pos, "uki_top",
+    placeholder_pos, "uki_outerwear",
+    placeholder_pos, "uki_face",
+    placeholder_pos, "uki_eyewear",
+    placeholder_pos, "uki_hair",
+)
+
+label show_uki_sprite(expression):
+    $ uki_expression = expression
+    show uki_sprite
 
 ## Mascot/Animal Sprites
 

--- a/game/sprites.rpy
+++ b/game/sprites.rpy
@@ -56,10 +56,6 @@ image uki_sprite = Composite(
     placeholder_pos, "uki_hair",
 )
 
-label show_uki_sprite(expression):
-    $ uki_expression = expression
-    show uki_sprite
-
 ## Mascot/Animal Sprites
 
 ## Enemy Sprites


### PR DESCRIPTION
Adds a new prototype screen for the dress-up minigame as well as the code for combining components into a single sprite for Uki. Note that since we don't actually have any assets yet, that code is untested and may not be functional.

Couldn't test the actual combining, but did check the variables and clicking Prev/Next on the dress-up screen properly updates the state for what outfit components Uki should be using.

This makes some assumptions on filenames, such as different hair components being named `hair0`, `hair1`, etc. in the `sprites/uki` folder and similarly for other component types. Also has some placeholders for component size and positioning and assumes four variants of each right now, to be updated with proper numbers later.

Screenshot (this is placeholder Uki image):
![dress_up_prototype](https://github.com/athamante/noctyx_before_corruption/assets/152583383/f80af97b-9908-4297-8b28-6f25fcabfed6)

